### PR TITLE
Update gulpfile.babel.js

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -67,7 +67,7 @@ gulp.task('html', ['styles'], () => {
   return gulp.src('app/*.html')
     .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
     .pipe($.if('*.js', $.uglify()))
-    .pipe($.if('*.css', $.cssnano({autoprefixer: false})))
+    .pipe($.if('*.css', $.cssnano({safe: true, autoprefixer: false})))
     .pipe($.if('*.html', $.htmlmin({collapseWhitespace: true})))
     .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
https://github.com/ben-eb/cssnano
"Note that cssnano enables aggressive optimisations by default, which might not always be what you want. Set options.safe to true if you want to disable this. In future versions, only safe options will be enabled by default, starting from version 4."

I have had several problems when using nano css. I have arranged this way:
.pipe($.if('*.css', $.cssnano({safe: true})))
